### PR TITLE
chore: release v0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9](https://github.com/bjackman/limmat/compare/v0.2.8...v0.2.9) - 2026-03-13
+
+### Other
+
+- Make un-wrapped package the default
+- Revert "flake: Fix limmat-wrapped definition"
+
 ## [0.2.8](https://github.com/bjackman/limmat/compare/v0.2.7...v0.2.8) - 2026-01-22
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "limmat"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "ansi-control-codes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limmat"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 license = "GPL-3.0-only"
 description = "Tool to run continuous tests locally on Git revision ranges."


### PR DESCRIPTION



## 🤖 New release

* `limmat`: 0.2.8 -> 0.2.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.9](https://github.com/bjackman/limmat/compare/v0.2.8...v0.2.9) - 2026-06-22

### Other

- *(deps)* bump actions/checkout from 6 to 7
- Make un-wrapped package the default
- Revert "flake: Fix limmat-wrapped definition"
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).